### PR TITLE
Change package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "rust-htmlescape"
-version = "0.2.0"
+name = "htmlescape"
+version = "0.2.1"
 authors = [ "Viktor Dahl <pazaconyoman@gmail.com>" ]
 
 [lib]


### PR DESCRIPTION
I had trouble using Cargo with this package name and got some comments in #rust channel on IRC to change the package name.
