### PR TITLE
Improve encode speed by ~50% 

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,11 +1,3 @@
-pub static MINIMAL_ENTITIES: [(char, &'static str); 5] = [
-    ('"', "&quot;"),
-    ('&', "&amp;"),
-    ('\'', "&#x27;"),
-    ('<', "&lt;"),
-    ('>', "&gt;")
-];
-
 pub static NAMED_ENTITIES: &'static[(&'static str, char)] = &[
     ("AElig", '\u{00C6}'),
     ("Aacute", '\u{00C1}'),


### PR DESCRIPTION
Moved entity lookup into match arms instead of using a function that does a binary search in static array, then boxes up the result, and then immediately unboxes it in the match.

Before cargo bench
```
running 4 tests
test bench_decode_attribute ... bench:   2,585,276 ns/iter (+/- 1,174,543) = 93 MB/s
test bench_decode_minimal   ... bench:   1,314,817 ns/iter (+/- 793,375) = 89 MB/s
test bench_encode_attribute ... bench:   2,103,300 ns/iter (+/- 874,982) = 54 MB/s
test bench_encode_minimal   ... bench:   1,799,386 ns/iter (+/- 889,072) = 63 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```

After cargo bench
```
running 4 tests
test bench_decode_attribute ... bench:   2,273,943 ns/iter (+/- 986,740) = 106 MB/s
test bench_decode_minimal   ... bench:   1,292,612 ns/iter (+/- 840,655) = 91 MB/s
test bench_encode_attribute ... bench:   1,528,778 ns/iter (+/- 725,928) = 74 MB/s
test bench_encode_minimal   ... bench:   1,177,384 ns/iter (+/- 560,557) = 96 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```