### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Example usage
 All example assume a `extern crate htmlescape;` and `use htmlescape::{relevant functions here};` is present.
 
-###Encoding
+### Encoding
 `htmlescape::encode_minimal()` encodes an input string using a minimal set of HTML entities.
 
 ```rust
@@ -16,7 +16,7 @@ assert_eq!(tag.as_slice(), "<title>Cats &amp; dogs</title>");
 There is also a `htmlescape::encode_attribute()` function for encoding strings that are to be used
 as html attribute values.
 
-###Decoding
+### Decoding
 `htmlescape::decode_html()` decodes an encoded string, replacing HTML entities with the
 corresponding characters. Named, hex, and decimal entities are supported. A `Result` value is
 returned, with either the decoded string in `Ok`, or an error in `Err`.
@@ -30,7 +30,7 @@ let decoded = match decode_html(encoded) {
 assert_eq!(decoded.as_slice(), "Cats & dogs");
 ```
 
-###Avoiding allocations
+### Avoiding allocations
 Both the encoding and decoding functions are available in forms that take a `Writer` for output rather
 than returning an `String`. These version can be used to avoid allocation and copying if the returned
 `String` was just going to be written to a `Writer` anyway.


### PR DESCRIPTION
Headings in the README are not properly rendered by GitHub without spaces after `###`